### PR TITLE
feat(custom-connectionId-userId): WEB-3445 added support for custom connectionId, userId along with some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,18 @@ Now you can activate Symbl transcriptions.
 activateTranscriptions({
     meeting: meeting, // From DyteClient.init
     symblAccessToken: 'ACCESS_TOKEN_FROM_SYMBL_AI',
+    connectionId: 'SOME_ARBITRARY_CONNECTION_ID', // optional,
+    speakerUserId: 'SOME_ARBITRARY_USER_ID_FOR_SPEAKER', // optional
 });
 ```
 
 This would ensure that your audio gets translated and resultant transcriptions get sent to all participants including `self` being referred by `meeting.self`.
+
+`connectionId` field is optional. If not passed, value of `meeting.meta.roomName` will be used as `connectionId`.
+
+`speakerUserId` field is optional. If not passed, value of `meeting.self.clientSpecificId` will be used as `speakerUserId`.
+
+
 
 If you want to show transcriptions to a participant or for `self`, you can do so using the following snippet.
 
@@ -76,3 +84,36 @@ curl -k -X POST "https://api.symbl.ai/oauth2/token:generate" \
       "appSecret": "YOUR_APP_SECRET"
     }'
 ```
+
+# How to subscribe to transcriptions of this conversation?
+
+Please pass a unique `connectionId` for this meeting and a unique `speakerUserId` for the speaker while activating treanscriptions using `activateTranscriptions` method.
+
+This would help you use subscribe API of Symbl, located at https://docs.symbl.ai/reference/subscribe-api along with better control over the speakers.
+
+# How to test Symbl integration quickly without having to integrate Dyte beforehand?
+
+To see the demo or to test the Symbl integration, please go to https://github.com/dyte-in/symbl-transcription and clone the repo and run the npm script named `dev`.
+
+```sh
+git clone https://github.com/dyte-in/symbl-transcription.git
+cd symbl-transcription
+npm install
+npm run dev
+```
+
+It will run a server on localhost:3000 serving the HTML containing the sample integration from index.html.
+
+Please use the following URL to see the Default Dyte Meeting interface.
+
+```text
+http://localhost:3000/?authToken=PUT_DYTE_PARTICIPANT_AUTH_TOKEN_HERE&symblAccessToken=PUT_SYMBL_ACCESS_TOKEN_HERE
+
+```
+
+In case you are still using v1 meetings, please use the following URL.
+```text
+http://localhost:3000/?authToken=PUT_DYTE_PARTICIPANT_AUTH_TOKEN_HERE&symblAccessToken=PUT_SYMBL_ACCESS_TOKEN_HERE&roomName=PUT_DYTE_ROOM_NAME_HERE
+```
+
+Once the Dyte UI is loaded, please turn on the Mic and grant permissions, if asked. Post that, try speaking sentences in English (default) to see the transcriptions.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,19 @@
 # Dyte <> Symbl.ai transcriptions
 
-## How to test this?
-
-Go to terminal
-
-Install the packages.
-`npm install`
-
-Run it locally
-`npm run dev`
-
-It will run a server on localhost:3000 serving the HTML containing the sample integration from index.html.
-
-Use the following URL to test.
-`
-http://localhost:3000/?authToken=PUT_DYTE_PARTICIPANT_AUTH_TOKEN_HERE&symblAccessToken=PUT_SYMBL_ACCESS_TOKEN_HERE
-`
+A quick and easy solution to integrate Symbl.ai's transcriptions and conversational AI services with Dyte's SDK.
 
 ## How to use it with Dyte?
 
-Find the Dyte integration logic in your codebase which may look like this
+1. Please find the Dyte integration logic in your codebase which may look like the following.
 
-```
+```js
 // Somewhere in your codebase
 const meeting = await DyteClient.init(...)
 ```
 
-On top of the file where integration was found, import this package.
+2. On top of the file where integration was found, import this package.
 
-```
+```js
 import {
     activateTranscriptions,
     deactivateTranscriptions,
@@ -37,9 +22,10 @@ import {
 } from '@dytesdk/symbl-transcription';
 ```
 
-Now you can activate Symbl transcriptions.
 
-```
+3. Now you can activate Symbl transcriptions.
+
+```js
 activateTranscriptions({
     meeting: meeting, // From DyteClient.init
     symblAccessToken: 'ACCESS_TOKEN_FROM_SYMBL_AI',
@@ -48,15 +34,14 @@ activateTranscriptions({
 });
 ```
 
-This would ensure that your audio gets translated and resultant transcriptions get sent to all participants including `self` being referred by `meeting.self`.
+This method internally connects with Symbl using Websocket connection & automatically forwards the audio to them, while your Mic is on. On receiving transcriptions from Symbl, we broadcast those transcriptions to all the participants of the meeting, including the speaker, being referred by `meeting.self` .
 
 `connectionId` field is optional. If not passed, value of `meeting.meta.roomName` will be used as `connectionId`.
 
 `speakerUserId` field is optional. If not passed, value of `meeting.self.clientSpecificId` will be used as `speakerUserId`.
 
 
-
-If you want to show transcriptions to a participant or for `self`, you can do so using the following snippet.
+4. If you want to show transcriptions to a participant or for `self`, you can do so using the following snippet.
 
 ```
 addTranscriptionsListener({
@@ -65,6 +50,11 @@ addTranscriptionsListener({
     transcriptionsCallback: (allFormattedTranscriptions) => { console.log(allFormattedTranscriptions); },
 })
 ```
+
+Above code snippet helps you segregate speakers from listeners.
+
+For example, If you know that a participant is only meant to act as a listener, you can avoid calling `activateTranscriptions` and simply only call `addTranscriptionsListener` that runs solely over Dyte, thus reducing concurrent connections to Symbl thus giving you a potential cost benefit.
+
 
 Using `transcriptionsCallback` you can populate the transcriptions in your app/website at any desired place.
 
@@ -75,10 +65,9 @@ Once meeting is over, deactivate the transcription generation.
 ```
 deactivateTranscriptions({
     meeting: meeting, // From DyteClient.init
-    symblAccessToken: 'ACCESS_TOKEN_FROM_SYMBL_AI',
 });
 ```
-In similar fashion, remove the transcriptions listener, once the meeting is over.
+In a similar fashion, remove the transcriptions listener, once the meeting is over.
 
 ```
 removeTranscriptionsListener({meeting: meeting});

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -1,0 +1,67 @@
+import DyteClient from '@dytesdk/web-core';
+import { defineCustomElements } from '@dytesdk/ui-kit/loader/index.es2017';
+import {
+    activateTranscriptions,
+    addTranscriptionsListener,
+} from '../src/index';
+
+defineCustomElements();
+
+const init = async () => {
+    try {
+        const url = new URL(window.location.href);
+        const roomName = url.searchParams.get('roomName') || '';
+        const authToken = url.searchParams.get('authToken') || '';
+        const symblAccessToken = url.searchParams.get('symblAccessToken') || '';
+
+        const meeting = await DyteClient.init({
+            authToken,
+            roomName,
+            apiBase: 'https://api.dyte.io',
+            defaults: {
+                audio: false,
+                video: false,
+            },
+        });
+
+        (document.getElementById('my-meeting') as any).meeting = meeting;
+        Object.assign(window, { meeting });
+
+        // Initialize speech client
+        await activateTranscriptions({
+            meeting,
+            languageCode: 'en-US',
+            symblAccessToken,
+        });
+
+        await addTranscriptionsListener({
+            meeting,
+            noOfTranscriptionsToCache: 200,
+            transcriptionsCallback: (transcriptions) => {
+                const transcription = document.getElementById('dyte-transcriptions') as HTMLDivElement;
+                const list = transcriptions.slice(-3);
+                transcription.innerHTML = '';
+                list.forEach((item) => {
+                    const speaker = document.createElement('span');
+                    speaker.classList.add('dyte-transcription-speaker');
+                    speaker.innerText = `${item.displayName}: `;
+
+                    const text = document.createElement('span');
+                    text.classList.add('dyte-transcription-text');
+                    text.innerText = item.text.toString().trim() !== '' ? item.text.toString().trim() : '...';
+
+                    const container = document.createElement('span');
+                    container.classList.add('dyte-transcription-line');
+                    container.appendChild(speaker);
+                    container.appendChild(text);
+
+                    transcription.appendChild(container);
+                });
+            },
+        });
+    } catch (e) {
+        console.log(e);
+    }
+};
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Transcription Demo</title>
+    <style>
+      body {
+        height: 100vh;
+        width: 100vw;
+      }
+
+      #dyte-transcriptions{
+        position: absolute;
+        z-index: 99999;
+        bottom: 15%;
+        width: 100%;
+        display:flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items:center;
+      }
+
+      .dyte-transcription-line{
+        display: block;
+        max-width: 80%;
+        text-align: center !important;
+      }
+      .dyte-transcription-speaker{
+        font-weight: 500;
+        color: orange;
+      }
+      .dyte-transcription-text{
+        color: white;
+      }
+    </style>
+</head>
+<body>
+    <dyte-meeting id="my-meeting" show-setup-screen="false"></dyte-meeting>
+    <div id="dyte-transcriptions"></div>
+    <script type="module" src="./demo/index.ts"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "devDependencies": {
         "@commitlint/cli": "^13.1.0",
         "@commitlint/config-conventional": "^13.1.0",
-        "@dytesdk/web-core": ">=0.26.0",
+        "@dytesdk/ui-kit": "^1.59.0",
+        "@dytesdk/web-core": "1.20.0",
         "@semantic-release/changelog": "^5.0.1",
         "@semantic-release/commit-analyzer": "^8.0.1",
         "@semantic-release/exec": "^5.0.0",
@@ -589,6 +590,18 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
+      "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.16.7",
       "dev": true,
@@ -902,62 +915,80 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@dytesdk/mediasoup-client": {
-      "version": "3.6.51",
-      "resolved": "https://registry.npmjs.org/@dytesdk/mediasoup-client/-/mediasoup-client-3.6.51.tgz",
-      "integrity": "sha512-2vrlVv5glRAef+GH9v9uszedqN6kCSH6MOJ2Gi+JePniYwKIZ5lKUlS399GehEgagASbjNUqlxBcfgk1Ylehcg==",
+    "node_modules/@dyteinternals/awaitqueue": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@dyteinternals/awaitqueue/-/awaitqueue-3.0.1.tgz",
+      "integrity": "sha512-KooI+0lfAu13gUMuVtYlW//ti6MEvhqU8PP3jCXFqU2FSETOKHdtpBfHmBCE/Ass6+EStsDiVKLyh5XHNh+hsg==",
       "dev": true,
       "dependencies": {
-        "@types/debug": "^4.1.7",
-        "@types/events": "^3.0.0",
-        "awaitqueue": "^2.3.3",
-        "bowser": "^2.11.0",
-        "debug": "^4.3.3",
-        "events": "^3.3.0",
-        "fake-mediastreamtrack": "^1.1.6",
-        "h264-profile-level-id": "^1.0.1",
-        "sdp-transform": "^2.14.1",
-        "supports-color": "^9.2.1"
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
+      }
+    },
+    "node_modules/@dyteinternals/mediasoup-client": {
+      "version": "3.6.86",
+      "resolved": "https://registry.npmjs.org/@dyteinternals/mediasoup-client/-/mediasoup-client-3.6.86.tgz",
+      "integrity": "sha512-DewaQkewxCYnQJ+ZdbpCtE4gBP4lmbq5TUigKSTYaTXbJwI+KFideciPju1bxszgSW+V3yNE6uoUy5RMzfPTsg==",
+      "dev": true,
+      "dependencies": {
+        "@dyteinternals/awaitqueue": "^3.0.1",
+        "@types/debug": "^4.1.7",
+        "bowser": "^2.11.0",
+        "debug": "^4.3.4",
+        "events": "^3.3.0",
+        "h264-profile-level-id": "^1.0.1",
+        "queue-microtask": "^1.2.3",
+        "sdp-transform": "^2.14.1"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mediasoup"
       }
     },
-    "node_modules/@dytesdk/mediasoup-client/node_modules/supports-color": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.2.tgz",
-      "integrity": "sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==",
+    "node_modules/@dyteinternals/utils": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@dyteinternals/utils/-/utils-1.12.0.tgz",
+      "integrity": "sha512-RlLLIgicE24SP2/lpJIfeLXhvlSTIs5JmJmyNSfYCYJvbEKtCzFeKMn6E0TuF+mFVJZyVC6QTNCma+PEkX/1jA==",
       "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      "dependencies": {
+        "axios": "^0.25.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/@dytesdk/ui-kit": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@dytesdk/ui-kit/-/ui-kit-1.59.0.tgz",
+      "integrity": "sha512-fqzx2fZSFMPO9aaAK9Wc0ZG4aEtdZGQybuCQB0l/RUlDps5AEbulNfXrUHA7IuZphN6AZ5qMvwZ3PY6ejPbKlg==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.1.0",
+        "@stencil/core": "^2.20.0",
+        "hark": "^1.2.3",
+        "lodash-es": "^4.17.21",
+        "resize-observer-polyfill": "^1.5.1"
       }
     },
     "node_modules/@dytesdk/web-core": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@dytesdk/web-core/-/web-core-0.28.2.tgz",
-      "integrity": "sha512-ghR4NInhDE1l91lkfNKw8/OghqD4cMZrRzku9SE/jPsQ4F0bcO7Yi4Alc2FZfRKJx4A41BTEXxKc0OtjHDIcVA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@dytesdk/web-core/-/web-core-1.20.0.tgz",
+      "integrity": "sha512-sY3dgTJPCrJqskh+qkAtcV55FtGslY2M5un8EkV2YG3KCLEheLIKhmNovfWpryUyEbXoNoJP2kyCZ3N5kDuf+A==",
       "dev": true,
       "dependencies": {
-        "@dytesdk/mediasoup-client": "^3.6.51",
-        "@opentelemetry/api": "^1.1.0",
-        "@opentelemetry/context-zone": "^1.3.1",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.29.2",
-        "@opentelemetry/resources": "^1.3.1",
-        "@opentelemetry/sdk-trace-base": "^1.3.1",
-        "@opentelemetry/sdk-trace-web": "^1.3.1",
-        "@opentelemetry/semantic-conventions": "^1.3.1",
+        "@dyteinternals/mediasoup-client": "3.6.86",
+        "@dyteinternals/utils": "^1.10.0",
+        "@protobuf-ts/runtime": "^2.7.0",
+        "awaitqueue": "^3.0.1",
         "axios": "^0.25.0",
         "bowser": "^2.11.0",
-        "loglevel": "^1.8.0",
-        "socket.io-client": "^4.4.1",
-        "uuid": "^8.3.2"
+        "sdp-transform": "^2.14.1",
+        "socket.io-client": "4.6.2",
+        "uuid": "^8.3.2",
+        "worker-timers": "7.0.60"
       }
     },
     "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader": {
@@ -1044,6 +1075,31 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-Ii3MrfY/GAIN3OhXNzpCKaLxHQfJF9qvwq/kEJYdqDxeIHa01K8sldugal6TmeeXl+WMvhv9cnVzUTaFFJF09A==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.4.2",
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
+      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==",
+      "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -1582,197 +1638,11 @@
         "@octokit/openapi-types": "^11.2.0"
       }
     },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
-      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/api-metrics": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.29.2.tgz",
-      "integrity": "sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/@opentelemetry/context-zone": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.3.1.tgz",
-      "integrity": "sha512-ttE6+gW1NWTySRgSxUNnza1VXC5CP4t5PiMSwjtd/VgnbF8l1euzImApobD0gf4Yn7m+4AFmVe+g7mjWGM6Ygw==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.3.1",
-        "zone.js": "^0.11.0"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/@opentelemetry/context-zone-peer-dep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.3.1.tgz",
-      "integrity": "sha512-Be6Nc2R/mFaS37f1ccaUlZoNBJqf5cvoAKFkieZ7AIePJ7FIugtFDSu3mTAgXfyOpIgDAHyDSAJ3FEJqsFDzvQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0",
-        "zone.js": "^0.10.2 || ^0.11.0"
-      }
-    },
-    "node_modules/@opentelemetry/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.3.1"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.29.2.tgz",
-      "integrity": "sha512-cCKF00/+H06LDFJwdU4ga4MNZAwpgzPF6Rp5gDJwl2cP9h/QnKWjXNlWYqJZ8dPeNt373HH4iF4HOmEBdE4sUQ==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/otlp-exporter-base": "0.29.2",
-        "@opentelemetry/otlp-transformer": "0.29.2",
-        "@opentelemetry/resources": "1.3.1",
-        "@opentelemetry/sdk-trace-base": "1.3.1"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.29.2.tgz",
-      "integrity": "sha512-tTK+v2ER9Rv7YQXLrCvZpPdNdvZx8TGdZtlK7TKnzpyMRBIf7lqV1Jl0VaHFml+cgVJcGtow/ER6k5uJ5W4kUQ==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.3.1"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.29.2.tgz",
-      "integrity": "sha512-Y6dJj+rhRGynxhLlgEJkdkXuLHdFG8igcSBv6oy3m3GHSSvZkyNV34dVjtZJ586mUXsbFuAf6uqjzteobewO1g==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/api-metrics": "0.29.2",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/resources": "1.3.1",
-        "@opentelemetry/sdk-metrics-base": "0.29.2",
-        "@opentelemetry/sdk-trace-base": "1.3.1"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
-      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/semantic-conventions": "1.3.1"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics-base": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.29.2.tgz",
-      "integrity": "sha512-7hhhZ/6YRRgAXOUTeCsbe6SIk3wZAdAHnEwGGp7aiVH5AOyioHyHInw4EHtowlD6dbLxUWURjh6k+Geht2zbxg==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/api-metrics": "0.29.2",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/resources": "1.3.1",
-        "lodash.merge": "4.6.2"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.3.1.tgz",
-      "integrity": "sha512-Or95QZ+9QyvAiwqj+K68z8bDDuyWF50c37w17D10GV1dWzg4Ezcectsu/GB61QcBxm3Y4br0EN5F5TpIFfFliQ==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/resources": "1.3.1",
-        "@opentelemetry/semantic-conventions": "1.3.1"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.3.1.tgz",
-      "integrity": "sha512-O88Uoh3I02CFPVkHDh5GQ60E2jR7msMR6QRLEIRHIJ10Xz/xwoo3HONS0a3On1SXTEkZiXjHjw17fT+ojBQyFg==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/sdk-trace-base": "1.3.1",
-        "@opentelemetry/semantic-conventions": "1.3.1"
-      },
-      "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
-      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
+    "node_modules/@protobuf-ts/runtime": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.3.tgz",
+      "integrity": "sha512-nivzCpg/qYD0RX2OmHOahJALb8ndjGmUhNBcTJ0BbXoqKwCSM6vYA+vegzS3rhuaPgbyC7Ec8idlnizzUfIRuw==",
+      "dev": true
     },
     "node_modules/@semantic-release/changelog": {
       "version": "5.0.1",
@@ -2014,6 +1884,19 @@
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
     },
+    "node_modules/@stencil/core": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
+      "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==",
+      "dev": true,
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=12.10.0",
+        "npm": ">=6.0.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "dev": true,
@@ -2080,9 +1963,9 @@
       }
     },
     "node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "dev": true,
       "dependencies": {
         "@types/ms": "*"
@@ -2171,9 +2054,9 @@
       "license": "MIT"
     },
     "node_modules/@types/ms": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -2830,12 +2713,15 @@
       }
     },
     "node_modules/awaitqueue": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-2.4.0.tgz",
-      "integrity": "sha512-9nTnPxVuxiuKFTHslm9ltnekUECJidOQ5kE6JpZUH77KrKqStQuWUW7JPB2GJZ7rOwWLcbToHiIXle/nJe1VpQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-3.0.2.tgz",
+      "integrity": "sha512-AVAtRwmf0DNSesMdyanFKKejTrOnjdKtz5LIDQFu2OTUgXvB/CRTYMrkPAF/2GCF9XBtYVxSwxDORlD41S+RyQ==",
       "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/axios": {
@@ -4438,22 +4324,22 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.2.tgz",
-      "integrity": "sha512-8ZQmx0LQGRTYkHuogVZuGSpDqYZtCM/nv8zQ68VZ+JkOpazJ7ICdsSpaO6iXwvaU30oFg5QJOJWj8zWqhbKjkQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
+      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
       "dev": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.0.3",
-        "ws": "~8.2.3",
+        "ws": "~8.11.0",
         "xmlhttprequest-ssl": "~2.0.0"
       }
     },
     "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -4472,9 +4358,9 @@
       }
     },
     "node_modules/engine.io-parser": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
-      "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.7.tgz",
+      "integrity": "sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -5145,15 +5031,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -5230,16 +5107,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/fake-mediastreamtrack": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/fake-mediastreamtrack/-/fake-mediastreamtrack-1.1.6.tgz",
-      "integrity": "sha512-lcoO5oPsW57istAsnjvQxNjBEahi18OdUhWfmEewwfPfzNZnji5OXuodQM+VnUPi/1HnQRJ6gBUjbt1TNXrkjQ==",
-      "dev": true,
-      "dependencies": {
-        "event-target-shim": "^5.0.1",
-        "uuid": "^8.1.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
@@ -5269,6 +5136,19 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-unique-numbers": {
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-8.0.12.tgz",
+      "integrity": "sha512-Z4AJueNDnuC/sLxeQqrHP4zgqcBIeQQLbQ0hEx1a7m6Wf7ERrdAyR7CkGfoEFWm9Qla7dpLt0eWPyiO18gqj0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.1.0"
+      }
     },
     "node_modules/fast-url-parser": {
       "version": "1.1.3",
@@ -5825,12 +5705,12 @@
       "license": "ISC"
     },
     "node_modules/h264-profile-level-id": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-1.0.1.tgz",
-      "integrity": "sha512-D3Rln/jKNjKDW5ZTJTK3niSoOGE+pFqPvRHHVgQN3G7umcn/zWGPUo8Q8VpDj16x3hKz++zVviRNRmXu5cpN+Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-1.0.2.tgz",
+      "integrity": "sha512-bsSv/bHq4eIUt4iMycA9rn1C28gtXwrKLAkbpzuZmkQp4u3M6QlF5y6DlTMy5fGDkVGbMLxFGeL7Ra8JKMm4Dg==",
       "dev": true,
       "dependencies": {
-        "debug": "^4.1.1"
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -5862,6 +5742,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/hark": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/hark/-/hark-1.2.3.tgz",
+      "integrity": "sha512-u68vz9SCa38ESiFJSDjqK8XbXqWzyot7Cj6Y2b6jk2NJ+II3MY2dIrLMg/kjtIAun4Y1DHF/20hfx4rq1G5GMg==",
+      "dev": true,
+      "dependencies": {
+        "wildemitter": "^1.2.0"
       }
     },
     "node_modules/has": {
@@ -7756,6 +7645,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "dev": true,
@@ -7830,19 +7725,6 @@
       "version": "4.7.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/loglevel": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
-      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/loglevel"
-      }
     },
     "node_modules/longest": {
       "version": "2.0.1",
@@ -16782,6 +16664,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+      "dev": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "dev": true,
@@ -16854,6 +16742,12 @@
       "dependencies": {
         "lodash": "^4.17.14"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -17550,24 +17444,24 @@
       }
     },
     "node_modules/socket.io-client": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.1.tgz",
-      "integrity": "sha512-e6nLVgiRYatS+AHXnOnGi4ocOpubvOUCGhyWw8v+/FxW8saHkinG6Dfhi9TU0Kt/8mwJIAASxvw6eujQmjdZVA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.2.tgz",
+      "integrity": "sha512-OwWrMbbA8wSqhBAR0yoPK6EdQLERQAYjXb3A0zLpgxfM1ZGLKoxHx8gVmCHA6pcclRX5oA/zvQf7bghAS11jRA==",
       "dev": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.2.1",
-        "socket.io-parser": "~4.2.0"
+        "engine.io-client": "~6.4.0",
+        "socket.io-parser": "~4.2.4"
       },
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.0.tgz",
-      "integrity": "sha512-tLfmEwcEwnlQTxFB7jibL/q2+q8dlVQzj4JdRLJ/W/G1+Fu9VSxCx1Lo+n1HvXxKnM//dUuD0xgiA7tQf57Vng==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
       "dev": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -18533,9 +18427,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -18917,6 +18812,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/wildemitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/wildemitter/-/wildemitter-1.2.1.tgz",
+      "integrity": "sha512-UMmSUoIQSir+XbBpTxOTS53uJ8s/lVhADCkEbhfRjUGFDPme/XGOb0sBWLx5sTz7Wx/2+TlAw1eK9O5lw5PiEw==",
+      "dev": true
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "dev": true,
@@ -18948,6 +18849,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/worker-timers": {
+      "version": "7.0.60",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-7.0.60.tgz",
+      "integrity": "sha512-kom5j7+JQU0uuJAqAeFvxPpKlp21BH09YLMU/JLKA+0Zs3WTGk7WSBFYjdR3G+kjXr6qWD7zIcenv3oXaWBJzw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.20.6",
+        "tslib": "^2.4.1",
+        "worker-timers-broker": "^6.0.80",
+        "worker-timers-worker": "^7.0.46"
+      }
+    },
+    "node_modules/worker-timers-broker": {
+      "version": "6.0.99",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-6.0.99.tgz",
+      "integrity": "sha512-MZPqEQrJH4gN6Q9ipPieTY5jXQpB0nUEJEpE/KyR88Fc8mRVmqzJjiNPkqLHyd1KDUAr7AlcKSPKceWxS6CV+A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.5",
+        "fast-unique-numbers": "^8.0.12",
+        "tslib": "^2.6.2",
+        "worker-timers-worker": "^7.0.63"
+      }
+    },
+    "node_modules/worker-timers-worker": {
+      "version": "7.0.63",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-7.0.63.tgz",
+      "integrity": "sha512-6CdgnG4ldY2Oowp+kJFydslyUzDXzG6PeWMTFeAhSWIofw/8FnvxHV4W6CDtKLMZXWByMTA+mqwVYasWuefTOw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.5",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/wrap-ansi": {
@@ -19147,15 +19082,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zone.js": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.5.tgz",
-      "integrity": "sha512-D1/7VxEuQ7xk6z/kAROe4SUbd9CzxY4zOwVGnGHerd/SgLIVU5f4esDzQUsOCeArn933BZfWMKydH7l7dPEp0g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
       }
     }
   },
@@ -19472,6 +19398,15 @@
         "@babel/helper-plugin-utils": "^7.17.12"
       }
     },
+    "@babel/runtime": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
+      "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.14.0"
+      }
+    },
     "@babel/template": {
       "version": "7.16.7",
       "dev": true,
@@ -19690,51 +19625,70 @@
         }
       }
     },
-    "@dytesdk/mediasoup-client": {
-      "version": "3.6.51",
-      "resolved": "https://registry.npmjs.org/@dytesdk/mediasoup-client/-/mediasoup-client-3.6.51.tgz",
-      "integrity": "sha512-2vrlVv5glRAef+GH9v9uszedqN6kCSH6MOJ2Gi+JePniYwKIZ5lKUlS399GehEgagASbjNUqlxBcfgk1Ylehcg==",
+    "@dyteinternals/awaitqueue": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@dyteinternals/awaitqueue/-/awaitqueue-3.0.1.tgz",
+      "integrity": "sha512-KooI+0lfAu13gUMuVtYlW//ti6MEvhqU8PP3jCXFqU2FSETOKHdtpBfHmBCE/Ass6+EStsDiVKLyh5XHNh+hsg==",
       "dev": true,
       "requires": {
+        "debug": "^4.3.4"
+      }
+    },
+    "@dyteinternals/mediasoup-client": {
+      "version": "3.6.86",
+      "resolved": "https://registry.npmjs.org/@dyteinternals/mediasoup-client/-/mediasoup-client-3.6.86.tgz",
+      "integrity": "sha512-DewaQkewxCYnQJ+ZdbpCtE4gBP4lmbq5TUigKSTYaTXbJwI+KFideciPju1bxszgSW+V3yNE6uoUy5RMzfPTsg==",
+      "dev": true,
+      "requires": {
+        "@dyteinternals/awaitqueue": "^3.0.1",
         "@types/debug": "^4.1.7",
-        "@types/events": "^3.0.0",
-        "awaitqueue": "^2.3.3",
         "bowser": "^2.11.0",
-        "debug": "^4.3.3",
+        "debug": "^4.3.4",
         "events": "^3.3.0",
-        "fake-mediastreamtrack": "^1.1.6",
         "h264-profile-level-id": "^1.0.1",
-        "sdp-transform": "^2.14.1",
-        "supports-color": "^9.2.1"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "9.2.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.2.tgz",
-          "integrity": "sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==",
-          "dev": true
-        }
+        "queue-microtask": "^1.2.3",
+        "sdp-transform": "^2.14.1"
+      }
+    },
+    "@dyteinternals/utils": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@dyteinternals/utils/-/utils-1.12.0.tgz",
+      "integrity": "sha512-RlLLIgicE24SP2/lpJIfeLXhvlSTIs5JmJmyNSfYCYJvbEKtCzFeKMn6E0TuF+mFVJZyVC6QTNCma+PEkX/1jA==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.25.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "@dytesdk/ui-kit": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@dytesdk/ui-kit/-/ui-kit-1.59.0.tgz",
+      "integrity": "sha512-fqzx2fZSFMPO9aaAK9Wc0ZG4aEtdZGQybuCQB0l/RUlDps5AEbulNfXrUHA7IuZphN6AZ5qMvwZ3PY6ejPbKlg==",
+      "dev": true,
+      "requires": {
+        "@floating-ui/dom": "^1.1.0",
+        "@stencil/core": "^2.20.0",
+        "hark": "^1.2.3",
+        "lodash-es": "^4.17.21",
+        "resize-observer-polyfill": "^1.5.1"
       }
     },
     "@dytesdk/web-core": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@dytesdk/web-core/-/web-core-0.28.2.tgz",
-      "integrity": "sha512-ghR4NInhDE1l91lkfNKw8/OghqD4cMZrRzku9SE/jPsQ4F0bcO7Yi4Alc2FZfRKJx4A41BTEXxKc0OtjHDIcVA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@dytesdk/web-core/-/web-core-1.20.0.tgz",
+      "integrity": "sha512-sY3dgTJPCrJqskh+qkAtcV55FtGslY2M5un8EkV2YG3KCLEheLIKhmNovfWpryUyEbXoNoJP2kyCZ3N5kDuf+A==",
       "dev": true,
       "requires": {
-        "@dytesdk/mediasoup-client": "^3.6.51",
-        "@opentelemetry/api": "^1.1.0",
-        "@opentelemetry/context-zone": "^1.3.1",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.29.2",
-        "@opentelemetry/resources": "^1.3.1",
-        "@opentelemetry/sdk-trace-base": "^1.3.1",
-        "@opentelemetry/sdk-trace-web": "^1.3.1",
-        "@opentelemetry/semantic-conventions": "^1.3.1",
+        "@dyteinternals/mediasoup-client": "3.6.86",
+        "@dyteinternals/utils": "^1.10.0",
+        "@protobuf-ts/runtime": "^2.7.0",
+        "awaitqueue": "^3.0.1",
         "axios": "^0.25.0",
         "bowser": "^2.11.0",
-        "loglevel": "^1.8.0",
-        "socket.io-client": "^4.4.1",
-        "uuid": "^8.3.2"
+        "sdp-transform": "^2.14.1",
+        "socket.io-client": "4.6.2",
+        "uuid": "^8.3.2",
+        "worker-timers": "7.0.60"
       }
     },
     "@endemolshinegroup/cosmiconfig-typescript-loader": {
@@ -19789,6 +19743,31 @@
           "dev": true
         }
       }
+    },
+    "@floating-ui/core": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-Ii3MrfY/GAIN3OhXNzpCKaLxHQfJF9qvwq/kEJYdqDxeIHa01K8sldugal6TmeeXl+WMvhv9cnVzUTaFFJF09A==",
+      "dev": true,
+      "requires": {
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "@floating-ui/dom": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+      "dev": true,
+      "requires": {
+        "@floating-ui/core": "^1.4.2",
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "@floating-ui/utils": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
+      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==",
+      "dev": true
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -20179,130 +20158,10 @@
         "@octokit/openapi-types": "^11.2.0"
       }
     },
-    "@opentelemetry/api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
-      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==",
-      "dev": true
-    },
-    "@opentelemetry/api-metrics": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.29.2.tgz",
-      "integrity": "sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==",
-      "dev": true,
-      "requires": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "@opentelemetry/context-zone": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.3.1.tgz",
-      "integrity": "sha512-ttE6+gW1NWTySRgSxUNnza1VXC5CP4t5PiMSwjtd/VgnbF8l1euzImApobD0gf4Yn7m+4AFmVe+g7mjWGM6Ygw==",
-      "dev": true,
-      "requires": {
-        "@opentelemetry/context-zone-peer-dep": "1.3.1",
-        "zone.js": "^0.11.0"
-      }
-    },
-    "@opentelemetry/context-zone-peer-dep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.3.1.tgz",
-      "integrity": "sha512-Be6Nc2R/mFaS37f1ccaUlZoNBJqf5cvoAKFkieZ7AIePJ7FIugtFDSu3mTAgXfyOpIgDAHyDSAJ3FEJqsFDzvQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "@opentelemetry/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
-      "dev": true,
-      "requires": {
-        "@opentelemetry/semantic-conventions": "1.3.1"
-      }
-    },
-    "@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.29.2.tgz",
-      "integrity": "sha512-cCKF00/+H06LDFJwdU4ga4MNZAwpgzPF6Rp5gDJwl2cP9h/QnKWjXNlWYqJZ8dPeNt373HH4iF4HOmEBdE4sUQ==",
-      "dev": true,
-      "requires": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/otlp-exporter-base": "0.29.2",
-        "@opentelemetry/otlp-transformer": "0.29.2",
-        "@opentelemetry/resources": "1.3.1",
-        "@opentelemetry/sdk-trace-base": "1.3.1"
-      }
-    },
-    "@opentelemetry/otlp-exporter-base": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.29.2.tgz",
-      "integrity": "sha512-tTK+v2ER9Rv7YQXLrCvZpPdNdvZx8TGdZtlK7TKnzpyMRBIf7lqV1Jl0VaHFml+cgVJcGtow/ER6k5uJ5W4kUQ==",
-      "dev": true,
-      "requires": {
-        "@opentelemetry/core": "1.3.1"
-      }
-    },
-    "@opentelemetry/otlp-transformer": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.29.2.tgz",
-      "integrity": "sha512-Y6dJj+rhRGynxhLlgEJkdkXuLHdFG8igcSBv6oy3m3GHSSvZkyNV34dVjtZJ586mUXsbFuAf6uqjzteobewO1g==",
-      "dev": true,
-      "requires": {
-        "@opentelemetry/api-metrics": "0.29.2",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/resources": "1.3.1",
-        "@opentelemetry/sdk-metrics-base": "0.29.2",
-        "@opentelemetry/sdk-trace-base": "1.3.1"
-      }
-    },
-    "@opentelemetry/resources": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
-      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
-      "dev": true,
-      "requires": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/semantic-conventions": "1.3.1"
-      }
-    },
-    "@opentelemetry/sdk-metrics-base": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.29.2.tgz",
-      "integrity": "sha512-7hhhZ/6YRRgAXOUTeCsbe6SIk3wZAdAHnEwGGp7aiVH5AOyioHyHInw4EHtowlD6dbLxUWURjh6k+Geht2zbxg==",
-      "dev": true,
-      "requires": {
-        "@opentelemetry/api-metrics": "0.29.2",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/resources": "1.3.1",
-        "lodash.merge": "4.6.2"
-      }
-    },
-    "@opentelemetry/sdk-trace-base": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.3.1.tgz",
-      "integrity": "sha512-Or95QZ+9QyvAiwqj+K68z8bDDuyWF50c37w17D10GV1dWzg4Ezcectsu/GB61QcBxm3Y4br0EN5F5TpIFfFliQ==",
-      "dev": true,
-      "requires": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/resources": "1.3.1",
-        "@opentelemetry/semantic-conventions": "1.3.1"
-      }
-    },
-    "@opentelemetry/sdk-trace-web": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.3.1.tgz",
-      "integrity": "sha512-O88Uoh3I02CFPVkHDh5GQ60E2jR7msMR6QRLEIRHIJ10Xz/xwoo3HONS0a3On1SXTEkZiXjHjw17fT+ojBQyFg==",
-      "dev": true,
-      "requires": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/sdk-trace-base": "1.3.1",
-        "@opentelemetry/semantic-conventions": "1.3.1"
-      }
-    },
-    "@opentelemetry/semantic-conventions": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
-      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
+    "@protobuf-ts/runtime": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.3.tgz",
+      "integrity": "sha512-nivzCpg/qYD0RX2OmHOahJALb8ndjGmUhNBcTJ0BbXoqKwCSM6vYA+vegzS3rhuaPgbyC7Ec8idlnizzUfIRuw==",
       "dev": true
     },
     "@semantic-release/changelog": {
@@ -20475,6 +20334,12 @@
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
     },
+    "@stencil/core": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
+      "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==",
+      "dev": true
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "dev": true
@@ -20529,9 +20394,9 @@
       }
     },
     "@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "dev": true,
       "requires": {
         "@types/ms": "*"
@@ -20607,9 +20472,9 @@
       "dev": true
     },
     "@types/ms": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
       "dev": true
     },
     "@types/node": {
@@ -20981,10 +20846,13 @@
       "dev": true
     },
     "awaitqueue": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-2.4.0.tgz",
-      "integrity": "sha512-9nTnPxVuxiuKFTHslm9ltnekUECJidOQ5kE6JpZUH77KrKqStQuWUW7JPB2GJZ7rOwWLcbToHiIXle/nJe1VpQ==",
-      "dev": true
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-3.0.2.tgz",
+      "integrity": "sha512-AVAtRwmf0DNSesMdyanFKKejTrOnjdKtz5LIDQFu2OTUgXvB/CRTYMrkPAF/2GCF9XBtYVxSwxDORlD41S+RyQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.4"
+      }
     },
     "axios": {
       "version": "0.25.0",
@@ -22059,31 +21927,31 @@
       }
     },
     "engine.io-client": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.2.tgz",
-      "integrity": "sha512-8ZQmx0LQGRTYkHuogVZuGSpDqYZtCM/nv8zQ68VZ+JkOpazJ7ICdsSpaO6iXwvaU30oFg5QJOJWj8zWqhbKjkQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
+      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
       "dev": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.0.3",
-        "ws": "~8.2.3",
+        "ws": "~8.11.0",
         "xmlhttprequest-ssl": "~2.0.0"
       },
       "dependencies": {
         "ws": {
-          "version": "8.2.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
           "dev": true,
           "requires": {}
         }
       }
     },
     "engine.io-parser": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
-      "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.7.tgz",
+      "integrity": "sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==",
       "dev": true
     },
     "enquirer": {
@@ -22522,12 +22390,6 @@
       "version": "2.0.3",
       "dev": true
     },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
-    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -22579,16 +22441,6 @@
         "tmp": "^0.0.33"
       }
     },
-    "fake-mediastreamtrack": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/fake-mediastreamtrack/-/fake-mediastreamtrack-1.1.6.tgz",
-      "integrity": "sha512-lcoO5oPsW57istAsnjvQxNjBEahi18OdUhWfmEewwfPfzNZnji5OXuodQM+VnUPi/1HnQRJ6gBUjbt1TNXrkjQ==",
-      "dev": true,
-      "requires": {
-        "event-target-shim": "^5.0.1",
-        "uuid": "^8.1.0"
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "dev": true
@@ -22611,6 +22463,16 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "dev": true
+    },
+    "fast-unique-numbers": {
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-8.0.12.tgz",
+      "integrity": "sha512-Z4AJueNDnuC/sLxeQqrHP4zgqcBIeQQLbQ0hEx1a7m6Wf7ERrdAyR7CkGfoEFWm9Qla7dpLt0eWPyiO18gqj0A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.23.5",
+        "tslib": "^2.6.2"
+      }
     },
     "fast-url-parser": {
       "version": "1.1.3",
@@ -22966,12 +22828,12 @@
       "dev": true
     },
     "h264-profile-level-id": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-1.0.1.tgz",
-      "integrity": "sha512-D3Rln/jKNjKDW5ZTJTK3niSoOGE+pFqPvRHHVgQN3G7umcn/zWGPUo8Q8VpDj16x3hKz++zVviRNRmXu5cpN+Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-1.0.2.tgz",
+      "integrity": "sha512-bsSv/bHq4eIUt4iMycA9rn1C28gtXwrKLAkbpzuZmkQp4u3M6QlF5y6DlTMy5fGDkVGbMLxFGeL7Ra8JKMm4Dg==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.1"
+        "debug": "^4.3.4"
       }
     },
     "handlebars": {
@@ -22988,6 +22850,15 @@
     "hard-rejection": {
       "version": "2.1.0",
       "dev": true
+    },
+    "hark": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/hark/-/hark-1.2.3.tgz",
+      "integrity": "sha512-u68vz9SCa38ESiFJSDjqK8XbXqWzyot7Cj6Y2b6jk2NJ+II3MY2dIrLMg/kjtIAun4Y1DHF/20hfx4rq1G5GMg==",
+      "dev": true,
+      "requires": {
+        "wildemitter": "^1.2.0"
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -24215,6 +24086,12 @@
       "version": "4.17.21",
       "dev": true
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "dev": true
@@ -24273,12 +24150,6 @@
     },
     "lodash.uniqby": {
       "version": "4.7.0",
-      "dev": true
-    },
-    "loglevel": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
-      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
       "dev": true
     },
     "longest": {
@@ -30755,6 +30626,12 @@
         }
       }
     },
+    "regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+      "dev": true
+    },
     "regexp.prototype.flags": {
       "version": "1.4.3",
       "dev": true,
@@ -30796,6 +30673,12 @@
       "requires": {
         "lodash": "^4.17.14"
       }
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true
     },
     "resolve": {
       "version": "1.22.0",
@@ -31242,21 +31125,21 @@
       }
     },
     "socket.io-client": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.1.tgz",
-      "integrity": "sha512-e6nLVgiRYatS+AHXnOnGi4ocOpubvOUCGhyWw8v+/FxW8saHkinG6Dfhi9TU0Kt/8mwJIAASxvw6eujQmjdZVA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.2.tgz",
+      "integrity": "sha512-OwWrMbbA8wSqhBAR0yoPK6EdQLERQAYjXb3A0zLpgxfM1ZGLKoxHx8gVmCHA6pcclRX5oA/zvQf7bghAS11jRA==",
       "dev": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.2.1",
-        "socket.io-parser": "~4.2.0"
+        "engine.io-client": "~6.4.0",
+        "socket.io-parser": "~4.2.4"
       }
     },
     "socket.io-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.0.tgz",
-      "integrity": "sha512-tLfmEwcEwnlQTxFB7jibL/q2+q8dlVQzj4JdRLJ/W/G1+Fu9VSxCx1Lo+n1HvXxKnM//dUuD0xgiA7tQf57Vng==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
       "dev": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -31889,7 +31772,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "tsutils": {
@@ -32138,6 +32023,12 @@
         "string-width": "^2.1.1"
       }
     },
+    "wildemitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/wildemitter/-/wildemitter-1.2.1.tgz",
+      "integrity": "sha512-UMmSUoIQSir+XbBpTxOTS53uJ8s/lVhADCkEbhfRjUGFDPme/XGOb0sBWLx5sTz7Wx/2+TlAw1eK9O5lw5PiEw==",
+      "dev": true
+    },
     "word-wrap": {
       "version": "1.2.3",
       "dev": true
@@ -32158,6 +32049,40 @@
           "version": "1.0.1",
           "dev": true
         }
+      }
+    },
+    "worker-timers": {
+      "version": "7.0.60",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-7.0.60.tgz",
+      "integrity": "sha512-kom5j7+JQU0uuJAqAeFvxPpKlp21BH09YLMU/JLKA+0Zs3WTGk7WSBFYjdR3G+kjXr6qWD7zIcenv3oXaWBJzw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.20.6",
+        "tslib": "^2.4.1",
+        "worker-timers-broker": "^6.0.80",
+        "worker-timers-worker": "^7.0.46"
+      }
+    },
+    "worker-timers-broker": {
+      "version": "6.0.99",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-6.0.99.tgz",
+      "integrity": "sha512-MZPqEQrJH4gN6Q9ipPieTY5jXQpB0nUEJEpE/KyR88Fc8mRVmqzJjiNPkqLHyd1KDUAr7AlcKSPKceWxS6CV+A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.23.5",
+        "fast-unique-numbers": "^8.0.12",
+        "tslib": "^2.6.2",
+        "worker-timers-worker": "^7.0.63"
+      }
+    },
+    "worker-timers-worker": {
+      "version": "7.0.63",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-7.0.63.tgz",
+      "integrity": "sha512-6CdgnG4ldY2Oowp+kJFydslyUzDXzG6PeWMTFeAhSWIofw/8FnvxHV4W6CDtKLMZXWByMTA+mqwVYasWuefTOw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.23.5",
+        "tslib": "^2.6.2"
       }
     },
     "wrap-ansi": {
@@ -32280,15 +32205,6 @@
     "yocto-queue": {
       "version": "0.1.0",
       "dev": true
-    },
-    "zone.js": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.5.tgz",
-      "integrity": "sha512-D1/7VxEuQ7xk6z/kAROe4SUbd9CzxY4zOwVGnGHerd/SgLIVU5f4esDzQUsOCeArn933BZfWMKydH7l7dPEp0g==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.3.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
       "types": "./types/index.d.ts"
     }
   },
+  "files": [
+    "dist",
+    "types",
+    "README.md"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dyte-in/symbl-transcription.git"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --ext .js --fix",
     "build": "tsc && vite build && vite build -c vite.umd.config.ts",
-    "dev": "VITE_DEV=true vite",
     "prepare": "is-ci || husky install",
     "prepublishOnly": "cp package.json package.json.bak && node prepublish.js",
     "postpublish": "mv package.json.bak package.json",

--- a/package.json
+++ b/package.json
@@ -32,16 +32,19 @@
     "build": "tsc && vite build && vite build -c vite.umd.config.ts",
     "prepare": "is-ci || husky install",
     "prepublishOnly": "cp package.json package.json.bak && node prepublish.js",
-    "postpublish": "mv package.json.bak package.json"
+    "postpublish": "mv package.json.bak package.json",
+    "dev": "vite"
   },
   "peerDepdendencies": {
     "@dytesdk/web-core": ">=0.26.0"
   },
-  "dependencies": {},
+  "dependencies": {
+  },
   "devDependencies": {
-    "@dytesdk/web-core": ">=0.26.0",
     "@commitlint/cli": "^13.1.0",
     "@commitlint/config-conventional": "^13.1.0",
+    "@dytesdk/ui-kit": "^1.59.0",
+    "@dytesdk/web-core": "1.20.0",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/exec": "^5.0.0",

--- a/src/audio_middleware.ts
+++ b/src/audio_middleware.ts
@@ -1,26 +1,69 @@
 import { getWebSocket } from './transcriptions_building_blocks';
 
+function isAudioInputSilent(inputData: Float32Array) {
+    let isSilent = true;
+    for (let index = 0; index < inputData.length; index += 1) {
+        if (inputData[index] !== 0) {
+            isSilent = false;
+            break;
+        }
+    }
+    return isSilent;
+}
+
+function downsampleBuffer(buffer: AudioBuffer, outSampleRate: number) {
+    const sampleRateRatio = buffer.sampleRate / outSampleRate;
+    const newLength = Math.round(buffer.length / sampleRateRatio);
+    const result = new Int16Array(newLength);
+    let offsetResult = 0;
+    let offsetBuffer = 0;
+    const inputData = buffer.getChannelData(0);
+
+    while (offsetResult < result.length) {
+        const nextOffsetBuffer = Math.round((offsetResult + 1) * sampleRateRatio);
+        let accum = 0;
+        let count = 0;
+        for (let i = offsetBuffer; i < nextOffsetBuffer && i < buffer.length; i += 1) {
+            accum += inputData[i];
+            count += 1;
+        }
+
+        result[offsetResult] = Math.min(1, accum / count) * 0x7fff;
+        offsetResult += 1;
+        offsetBuffer = nextOffsetBuffer;
+    }
+    return result.buffer;
+}
+
 // Actual middleware to apply on Dyte
 async function audioTranscriptionMiddleware(audioContext: AudioContext) {
     const processor = audioContext.createScriptProcessor(1024, 1, 1);
 
-    processor.onaudioprocess = (e) => {
-        const inputData = e.inputBuffer.getChannelData(0) || new Float32Array(this.bufferSize);
-        const outputData = e.outputBuffer.getChannelData(0);
+    processor.onaudioprocess = (audioProcessingEvent) => {
+        const inputData = (
+            audioProcessingEvent.inputBuffer.getChannelData(0)
+            || new Float32Array(this.bufferSize)
+        );
+
+        // Stale processors might be floating around, do nothing for stale processors.
+        if (isAudioInputSilent(inputData)) {
+            return;
+        }
+
+        const outputData = audioProcessingEvent.outputBuffer.getChannelData(0);
 
         // Output to the buffer to not halt audio output
         inputData.forEach((val, index) => {
             outputData[index] = val;
         });
-
-        const targetBuffer = new Int16Array(inputData.length);
-        for (let index = inputData.length; index > 0; index -= 1) {
-            targetBuffer[index] = 32767 * Math.min(1, inputData[index]);
-        }
         // Send audio stream to websocket.
         const ws = getWebSocket();
         if (ws?.readyState === WebSocket.OPEN) {
-            ws.send(targetBuffer.buffer);
+            const downsampledBuffer = downsampleBuffer(
+                audioProcessingEvent.inputBuffer,
+                16000,
+            );
+            ws.send(downsampledBuffer);
         }
     };
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,7 +1,0 @@
-interface ImportMetaEnv extends Readonly<Record<string, string>> {
-    readonly DEV: string,
-}
-
-interface ImportMeta {
-    readonly env: ImportMetaEnv
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,16 +53,3 @@ export {
     removeTranscriptionsListener,
     getTranscriptions,
 };
-
-const isLocal = import.meta.env.DEV;
-if (isLocal) {
-    Object.assign(window, {
-        Symbl: {
-            activateTranscriptions,
-            deactivateTranscriptions,
-            addTranscriptionsListener,
-            removeTranscriptionsListener,
-            getTranscriptions,
-        },
-    });
-}

--- a/src/param_types.ts
+++ b/src/param_types.ts
@@ -1,5 +1,5 @@
-import DyteClient from '@dytesdk/web-core/types/client/DyteClient';
-import { BroadcastMessagePayload } from '@dytesdk/web-core/types/client/DyteParticipants';
+import type DyteClient from '@dytesdk/web-core';
+import type { BroadcastMessagePayload } from '@dytesdk/web-core/';
 
 export interface ActivateTranscriptionsConfig {
     meeting: DyteClient,

--- a/src/param_types.ts
+++ b/src/param_types.ts
@@ -5,6 +5,8 @@ export interface ActivateTranscriptionsConfig {
     meeting: DyteClient,
     symblAccessToken: string,
     languageCode?: string,
+    connectionId?: string,
+    speakerUserId?: string,
 }
 
 export interface DeactivateTranscriptionsConfig {

--- a/src/symbl_transcriptions.ts
+++ b/src/symbl_transcriptions.ts
@@ -19,13 +19,15 @@ async function activateTranscriptions({
     meeting,
     symblAccessToken,
     languageCode,
+    connectionId,
+    speakerUserId,
 }: ActivateTranscriptionsConfig) {
     // As a fail-safe, deactivateTranscriptions if activateTranscriptions function is called twice
     // eslint-disable-next-line no-use-before-define
     deactivateTranscriptions({ meeting });
 
-    const uniqueMeetingId = meeting.meta.roomName;
-    const symblEndpoint = `wss://api.symbl.ai/v1/streaming/${uniqueMeetingId}?access_token=${symblAccessToken}`;
+    const symblConnectionId = connectionId || meeting.meta.roomName;
+    const symblEndpoint = `wss://api.symbl.ai/v1/streaming/${symblConnectionId}?access_token=${symblAccessToken}`;
 
     const ws = new WebSocket(symblEndpoint);
     setWebSocket(ws);
@@ -105,7 +107,8 @@ async function activateTranscriptions({
                 },
             },
             speaker: {
-                peerId: meeting.self.id, // this if has email, gets transcription at the end
+                // this if has email, gets transcription at the end
+                userId: speakerUserId || meeting.self.clientSpecificId || meeting.self.id,
                 name: meeting.self.name,
             },
         }));

--- a/src/symbl_transcriptions.ts
+++ b/src/symbl_transcriptions.ts
@@ -50,6 +50,7 @@ async function activateTranscriptions({
                             endTimeISO: message.duration?.endTime || new Date().toISOString(),
                             peerId: meeting.self.id,
                             displayName: meeting.self.name,
+                            id: message.id,
                         },
                     );
                 }
@@ -103,7 +104,7 @@ async function activateTranscriptions({
                 languageCode, // Symbl has bug. This field is not honoured
                 speechRecognition: {
                     encoding: 'LINEAR16',
-                    sampleRateHertz: 44100,
+                    sampleRateHertz: 16000,
                 },
             },
             speaker: {

--- a/src/symbl_transcriptions.ts
+++ b/src/symbl_transcriptions.ts
@@ -107,9 +107,11 @@ async function activateTranscriptions({
                 },
             },
             speaker: {
-                // this if has email, gets transcription at the end
+                // if speaker has email key, transcription gets sent at the end
+                // speaker supports all arbitary values
                 userId: speakerUserId || meeting.self.clientSpecificId || meeting.self.id,
                 name: meeting.self.name,
+                peerId: meeting.self.id,
             },
         }));
     };

--- a/src/transcriptions_building_blocks.ts
+++ b/src/transcriptions_building_blocks.ts
@@ -1,4 +1,4 @@
-import { BroadcastMessagePayload } from '@dytesdk/web-core/types/client/DyteParticipants';
+import type { BroadcastMessagePayload } from '@dytesdk/web-core';
 
 let ws: WebSocket;
 

--- a/src/transcripts_listener.ts
+++ b/src/transcripts_listener.ts
@@ -4,7 +4,7 @@
  * This is being done to propagate User Name against their transcriptions.
  */
 
-import { BroadcastMessagePayload } from '@dytesdk/web-core/types/client/DyteParticipants';
+import type { BroadcastMessagePayload } from '@dytesdk/web-core';
 import {
     AddTranscriptionsListenerConfig,
     RemoveTranscriptionsListenerConfig,


### PR DESCRIPTION
[WEB-3445](https://linear.app/dyte/issue/WEB-3445/allow-passing-unique-connection-id-and-speaker-userid)

1. Added support for passing connectionId and speakerUserId.
2. Fixed device audio sampling issues where devices that could only support lower sample rate were not working.
3. Refactored the SDK code to remove non-essential code from the actual SDK build.
4. Added temp fix for Stale AudioContext & processor issue where the old processor is still running and feeding Symbl with audio buffers with all zero values (silent track). This was causing Symbl transcriptions to not show in case of device switch.
5. Updated README for new fields. Added a quick way to test locally.
